### PR TITLE
Updated missing single quote in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Text::vCard::Precisely - Read, Write and Edit the vCards 3.0 and/or 4.0 precisel
        street    => 'Waters Edge',
        city      => 'Baytown',
        region    => 'LA',
-       post_code => '30314,
+       post_code => '30314',
        country   => 'United States of America',
     });
 

--- a/lib/Text/vCard/Precisely.pm
+++ b/lib/Text/vCard/Precisely.pm
@@ -65,7 +65,7 @@ Text::vCard::Precisely - Read, Write and Edit the vCards 3.0 and/or 4.0 precisel
     street    => 'Waters Edge',
     city      => 'Baytown',
     region    => 'LA',
-    post_code => '30314,
+    post_code => '30314',
     country   => 'United States of America',
  });
 


### PR DESCRIPTION
There was a missing single quote around the zip code in the documentation.