### PR TITLE
as_file

### DIFF
--- a/lib/Text/vCard/Precisely/Multiple.pm
+++ b/lib/Text/vCard/Precisely/Multiple.pm
@@ -87,7 +87,7 @@ sub as_file {
     croak "No filename was set!" unless $filename;
 
     my $file = path($filename);
-    $file->spew_utf8( $self->as_string() );
+    $file->spew( $self->as_string() );
     return $file;
 }
 

--- a/lib/Text/vCard/Precisely/V3.pm
+++ b/lib/Text/vCard/Precisely/V3.pm
@@ -358,7 +358,7 @@ sub as_file {
     croak "No filename was set!" unless $filename;
 
     my $file = path($filename);
-    $file->spew_utf8( $self->as_string() );
+    $file->spew( $self->as_string() );
     return $file;
 }
 


### PR DESCRIPTION
Hi Yuki,


change for `as_file`, for #22 

--> works for me with this small change.

Tested with this script
```perl
#!/usr/bin/perl
use strict;
use warnings;
use utf8;
use Encode qw(encode_utf8);

use Text::vCard::Precisely;    
use Text::vCard::Precisely::Multiple;
my $vc = Text::vCard::Precisely->new( version => '4.0' );
my $vcm = Text::vCard::Precisely::Multiple->new( version => '4.0' );

my $fn = "Först Last";
print encode_utf8 "$fn is\n";
printf '%vX', $fn;
print "\n";

$vc->fn( encode_utf8 $fn );
$vcm->add_option($vc);


$vc->as_file( "22_single_as_file.vcf");

my $str = $vc->as_string();
open my $out, '>', '22_single_as_string.vcf' or die $!;
print $out  $str;
close $out;

$vcm->as_file('22_multiple_as_file.vcf');

$str = $vcm->as_string();
open $out, '>', '22_multiple_as_string.vcf' or die $!;
print $out  $str;
close $out;
```

For this small script, it even works with
```perl
$vc->fn( $fn );
```
instead of
```perl
$vc->fn( encode_utf8 $fn );
```
and even without `use utf8;`, probably because everything on a Linux system is UTF-8 per default, nowadays.

Tested with my final script, which reads data with `Spreadsheet::Read` from a LibreOffice Calc (.ods) file. It's also UTF-8, but for this I have to `encode_utf8` each and any `Text::vCard::Precisely...` call, as before, fine also.